### PR TITLE
Tense edit to COGA EdNote in SOTD.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
       <h2>Editor's Note: Contributing to this Document</h2>
       <p>This publication is a First Public Working Draft Note (FPWD) of a document intended to become an <a href="https://www.w3.org/2021/Process-20211102/#note-track">Accessible Platform Architectures (APA) Note.</a> The intent of this+(and all) APA First Public Working Draft Note publications is to gain a wider review of its content and solicit feedback on user needs that may have been missed, underrepresented, or sub-optimally described at this early draft stage.</p>
 
-      <p>One known area where feedback is needed and expected is how collaboration tools can support people with cognitive and learning disability. The W3C Cognitive and Learning Disability Task Force (COGA TF) is actively reviewing this draft, and is expected to provide feedback for incorporation in a future draft of this document based on their work in this area. An
+      <p>One known area where feedback is needed and expected is how collaboration tools can support people with cognitive and learning disability. The W3C Cognitive and Learning Disability Task Force (COGA TF) is actively reviewing this draft, and is providing feedback for incorporation in a future draft of this document based on their work in this area. An
 <a href="https://www.w3.org/WAI/GL/task-forces/coga/wiki/Feedback_on_CTAUR#Formal_Feedback">early view of COGA input to this document is available</a>.</p>
 
 <p>APA encourages review and feedback in other areas to ensure future drafts are as comprehensive as possible.</p>
     </section>
     </section>
-    
+
     <section>
       <h2>Introduction</h2>
       <section id="collaboration-tools">


### PR DESCRIPTION
What previously read "is expected to provide" now reads "is providing."

