### PR TITLE
comment on description of the document's type

### DIFF
--- a/messaging/3.w3c-news.md
+++ b/messaging/3.w3c-news.md
@@ -1,11 +1,10 @@
 WAI News:
-FOR REVIEW: Collaboration Tool Accessibility user Requirements First
-Public Working Draft
+FOR REVIEW: Collaboration Tools Accessibility User Requirements First Public Draft Note
 
-The Accessible Platform Architectures (APA) Research Questions Task Force (RQTF) welcomes feedback on the First Public Working Draft of the Collaboration  Tool Accessibility User Requirements.
+The Accessible Platform Architectures (APA) Research Questions Task Force (RQTF) welcomes feedback on the first public Draft Note of the Collaboration  Tool Accessibility User Requirements.
 
 
-The purpose of this Note is to outline various accessibility-related user needs, requirements and scenarios for collaboration tools.
+The purpose of this document is to outline various accessibility-related user needs, requirements and scenarios for collaboration tools.
 
 
 
@@ -19,7 +18,7 @@ may be implemented in the collaboration tool itself, or elsewhere, for example i
 
 
 
-The solutions identified in this Note are intended to influence the
+The solutions identified in this document are intended to influence the
 evolution of future accessibility guidelines, technical
 specifications, or features of collaboration tools and assistive
 technologies. They are relevant to software developers who
@@ -39,5 +38,5 @@ To comment, please use one of the following methods:
 
 
 
-Please send comments by  Friday 30 December 2022*.
+Please send comments by Friday 30 December 2022*.
 


### PR DESCRIPTION
I think it's more accurate to cite it as a [first public Draft Note](https://www.w3.org/standards/types#DNOTE) following [Note Track](https://www.w3.org/standards/types#notes), instead of [First Public Working Draft](https://www.w3.org/standards/types#FPWD) which follows [Standards Track](https://www.w3.org/standards/types#standardtrack).